### PR TITLE
Added cloning and copying of utf repo files

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -2,8 +2,8 @@
 DEPENDENCIES/repy_v1/*
 DEPENDENCIES/portability/*
 DEPENDENCIES/common/*
-DEPENDENCIES/common/utf/*
 # Tests
+test DEPENDENCIES/utf/*
 test tests/*
 test test/*
 test DEPENDENCIES/nodemanager/servicelogger.py

--- a/scripts/config_initialize.txt
+++ b/scripts/config_initialize.txt
@@ -2,3 +2,4 @@ https://github.com/SeattleTestbed/repy_v1 ../DEPENDENCIES/repy_v1
 https://github.com/SeattleTestbed/portability ../DEPENDENCIES/portability
 https://github.com/SeattleTestbed/common ../DEPENDENCIES/common
 https://github.com/SeattleTestbed/nodemanager ../DEPENDENCIES/nodemanager
+https://github.com/SeattleTestbed/utf ../DEPENDENCIES/utf


### PR DESCRIPTION
'utf' directory is to be deleted from 'common' repo and to be cloned separately from its own repo.
Hence, build-scripts needs to be updated to reflect that change.
This PR takes care of that.
